### PR TITLE
コメント編集/削除機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,10 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
+
+  def access_limit(model)
+    if current_user.id != model.user_id
+        redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -42,11 +42,7 @@ class CommentsController < ApplicationController
 
   private
 
-    # def comment_params
-    #   params.require(:comment).permit(:comment,:post_id).merge(user_id: current_user.id)
-    # end
-
     def comment_params
-      params.require(:comment).permit(:comment).merge(user_id: current_user.id, post_id: params[:post_id])
+      params.require(:comment).permit(:comment,:post_id).merge(user_id: current_user.id)
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,7 +29,11 @@ class CommentsController < ApplicationController
 
   private
 
+    # def comment_params
+    #   params.require(:comment).permit(:comment,:post_id).merge(user_id: current_user.id)
+    # end
+
     def comment_params
-      params.require(:comment).permit(:comment,:post_id).merge(user_id: current_user.id)
+      params.require(:comment).permit(:comment).merge(user_id: current_user.id, post_id: params[:post_id])
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,12 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    redirect_to post_path(params[:post_id])
+  end
+
   private
 
     def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,11 +6,7 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to post_path(params[:post_id])
     else
-      respond_to do |format|
-        format.js {  @comment.errors.full_messages.each do |message|
-          flash.now[:alert] = message
-        end }
-      end
+      respond_alert
     end
   end
 
@@ -25,11 +21,7 @@ class CommentsController < ApplicationController
     if @comment.update(comment_params)
       redirect_to post_path(params[:post_id])
     else
-      respond_to do |format|
-        format.js {  @comment.errors.full_messages.each do |message|
-          flash.now[:alert] = message
-        end }
-      end
+      respond_alert
     end
   end
 
@@ -49,6 +41,14 @@ class CommentsController < ApplicationController
 
       if current_user.id != @comment.user_id
         redirect_to post_path(params[:post_id])
+      end
+    end
+
+    def respond_alert
+      respond_to do |format|
+        format.js {  @comment.errors.full_messages.each do |message|
+          flash.now[:alert] = message
+        end }
       end
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
-  before_action :access_limit, only: [:edit, :update, :destroy]
   before_action :set_comment, only: [:edit, :update, :destroy]
+  before_action -> { access_limit(@comment) }, only: [:edit, :update, :desroy]
   
   def create
     @comment = Comment.new(comment_params)
@@ -37,13 +37,8 @@ class CommentsController < ApplicationController
       params.require(:comment).permit(:comment,:post_id).merge(user_id: current_user.id)
     end
 
-    def access_limit
     def set_comment
       @comment = Comment.find(params[:id])
-
-      if current_user.id != @comment.user_id
-        redirect_to post_path(params[:post_id])
-      end
     end
 
     def respond_alert

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,14 @@ class CommentsController < ApplicationController
     end
   end
 
+  def edit
+    @comment = Comment.find(params[:id])
+    # posts#showへ
+    @post = Post.find(params[:post_id])
+    @comments = @post.comments.eager_load(:user)
+    render "posts/show"
+  end
+
   def destroy
     @comment = Comment.find(params[:id])
     @comment.destroy

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,6 +21,19 @@ class CommentsController < ApplicationController
     render "posts/show"
   end
 
+  def update
+    @comment = Comment.find(params[:id])
+    if @comment.update(comment_params)
+      redirect_to post_path(params[:post_id])
+    else
+      respond_to do |format|
+        format.js {  @comment.errors.full_messages.each do |message|
+          flash.now[:alert] = message
+        end }
+      end
+    end
+  end
+
   def destroy
     @comment = Comment.find(params[:id])
     @comment.destroy

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,7 +17,7 @@ class CommentsController < ApplicationController
   def edit
     # posts#showへ
     @post = Post.find(params[:post_id])
-    @comments = @post.comments.eager_load(:user)
+    @comments = @post.comments.eager_load(:user).order(created_at: "DESC")
     render "posts/show"
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
-
+  before_action :access_limit, only: [:edit, :update, :destroy]
+  
   def create
     @comment = Comment.new(comment_params)
     if @comment.save
@@ -14,7 +15,6 @@ class CommentsController < ApplicationController
   end
 
   def edit
-    @comment = Comment.find(params[:id])
     # posts#showへ
     @post = Post.find(params[:post_id])
     @comments = @post.comments.eager_load(:user)
@@ -22,7 +22,6 @@ class CommentsController < ApplicationController
   end
 
   def update
-    @comment = Comment.find(params[:id])
     if @comment.update(comment_params)
       redirect_to post_path(params[:post_id])
     else
@@ -35,7 +34,6 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = Comment.find(params[:id])
     @comment.destroy
     redirect_to post_path(params[:post_id])
   end
@@ -44,5 +42,13 @@ class CommentsController < ApplicationController
 
     def comment_params
       params.require(:comment).permit(:comment,:post_id).merge(user_id: current_user.id)
+    end
+
+    def access_limit
+      @comment = Comment.find(params[:id])
+
+      if current_user.id != @comment.user_id
+        redirect_to post_path(params[:post_id])
+      end
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   before_action :access_limit, only: [:edit, :update, :destroy]
+  before_action :set_comment, only: [:edit, :update, :destroy]
   
   def create
     @comment = Comment.new(comment_params)
@@ -37,6 +38,7 @@ class CommentsController < ApplicationController
     end
 
     def access_limit
+    def set_comment
       @comment = Comment.find(params[:id])
 
       if current_user.id != @comment.user_id

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,7 +22,7 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
     @comment = Comment.new
-    @comments = @post.comments.eager_load(:user)
+    @comments = @post.comments.eager_load(:user).order(created_at: "DESC")
   end
 
   def edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :access_limit, only: [:edit, :update, :destroy]
   before_action :set_post, only: [:edit, :update, :destroy]
+  before_action -> { access_limit(@post) }, only: [:edit, :update, :destroy]
 
   def index
     @posts = Post.eager_load(:user).all.order(created_at: "DESC")
@@ -47,12 +47,7 @@ class PostsController < ApplicationController
     params.require(:post).permit(:content).merge(user_id: current_user.id)
   end
 
-  def access_limit
   def set_post
     @post = Post.find(params[:id])
-
-    if current_user.id != @post.user_id
-      redirect_to root_path
-    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :access_limit, only: [:edit, :update, :destroy]
+  before_action :set_post, only: [:edit, :update, :destroy]
 
   def index
     @posts = Post.eager_load(:user).all.order(created_at: "DESC")
@@ -47,6 +48,7 @@ class PostsController < ApplicationController
   end
 
   def access_limit
+  def set_post
     @post = Post.find(params[:id])
 
     if current_user.id != @post.user_id

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :access_limit, only: [:edit, :update, :destroy]
 
   def index
-    @posts = Post.eager_load(:user).all
+    @posts = Post.eager_load(:user).all.order(created_at: "DESC")
   end
 
   def new

--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,0 +1,1 @@
+$(".notifications").html(`<div class="alert"><%= flash.now[:alert] %></div>`)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -69,7 +69,7 @@
           <%= form_with model: [@post, @comment], remote: true do |f| %>
             <div class="comment_area__form_box__form">
               <div class="comment_area__form_box__form__hidden_field">
-                <%# <%= f.hidden_field :post_id, value: params[:id] %>
+                <%= f.hidden_field :post_id, value: @post.id %>
               </div>
               <div class="comment_area__form_box__form__field">
                 <%= f.text_area :comment, placeholder:"コメントを入力" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -53,8 +53,10 @@
             </div>
             <div class="comment_area__list__comment__right_box">
               <div class="comment_area__list__comment__right_box__info">
-                <%= link_to "編集", edit_post_comment_path(post_id: @post.id, id: comment.id) %>
-                <%= link_to "削除", post_comment_path(post_id: @post.id, id: comment.id), method: :delete, data: {confirm: "本当に削除して良いですか?",cancel: "やめる",commit: "削除する"}, title: "削除確認" %>
+                <% if user_signed_in? && (comment.user_id == current_user.id) %>
+                  <%= link_to "編集", edit_post_comment_path(post_id: @post.id, id: comment.id) %>
+                  <%= link_to "削除", post_comment_path(post_id: @post.id, id: comment.id), method: :delete, data: {confirm: "本当に削除して良いですか?",cancel: "やめる",commit: "削除する"}, title: "削除確認" %>
+                <% end %>
                 <span>投稿日時：<%= comment.updated_at.strftime("%Y-%m-%d %H:%M") %></span>
               </div>
               <div class="comment_area__list__comment__right_box__text">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -69,7 +69,7 @@
           <%= form_with model: [@post, @comment], remote: true do |f| %>
             <div class="comment_area__form_box__form">
               <div class="comment_area__form_box__form__hidden_field">
-                <%= f.hidden_field :post_id, value: params[:id] %>
+                <%# <%= f.hidden_field :post_id, value: params[:id] %>
               </div>
               <div class="comment_area__form_box__form__field">
                 <%= f.text_area :comment, placeholder:"コメントを入力" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -53,8 +53,8 @@
             </div>
             <div class="comment_area__list__comment__right_box">
               <div class="comment_area__list__comment__right_box__info">
-                <span>編集</span>
-                <span>削除</span>
+                <%= link_to "編集", edit_post_comment_path(post_id: @post.id, id: comment.id) %>
+                <%= link_to "削除", post_comment_path(post_id: @post.id, id: comment.id), method: :delete, data: {confirm: "本当に削除して良いですか?",cancel: "やめる",commit: "削除する"}, title: "削除確認" %>
                 <span>投稿日時：<%= comment.updated_at.strftime("%Y-%m-%d %H:%M") %></span>
               </div>
               <div class="comment_area__list__comment__right_box__text">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
     post 'users/guest_sign_in', to: 'users/sessions#new_guest'
   end
   resources :posts do
-    resources :comments, only: [:create]
+    resources :comments, only: [:create, :edit, :update, :destroy]
   end
 end


### PR DESCRIPTION
## 要件
- コメント内容を変更することができる
  - `posts/show.html.erb` でコメント投稿者のみに編集・削除リンクを表示
- コメントを削除することができる
  - `comments#destroy` にて
- コメントを編集・削除できるのはコメント投稿者のみ
  - `posts/show.html.erb` でコメント投稿者のみに編集・削除リンクを表示
  - `comments_controller.rb` に`access_limit` を作成し、コメント投稿者以外のアクセスは掲示板詳細にリダイレクト
- 編集画面を開いた時点で、既に登録されているコメント内容が表示されている
  - `comments#edit`で `posts#show` をレンダリング
- 投稿内容が必須になっている（ブランクのまま投稿できないようになっている）
  - PR #9 で実装済みのため、追加の記述はなし
- バリデーションに反した際に、エラーメッセージが表示される
  - `comments#update` の `else~`で対応
## その他
- 掲示板一覧とコメント一覧を降順に変更（`.order(created_at: "DESC"` を追記）
  - `@posts` → `posts#index`
  - `@comments` → `posts#show` と `comments#edit`

## 画像
- コメント内容の変更（編集画面を開いた時点で、既に登録されているコメント内容が表示）
[![Image from Gyazo](https://i.gyazo.com/1c3444f761e6768901571f79532785f5.gif)](https://gyazo.com/1c3444f761e6768901571f79532785f5)

- コメント内容の削除
[![Image from Gyazo](https://i.gyazo.com/c814074d1066125d3cd5d437a92dbeaf.gif)](https://gyazo.com/c814074d1066125d3cd5d437a92dbeaf)

- コメント編集は投稿者のみ
[![Image from Gyazo](https://i.gyazo.com/d97829357aaab77bc5047d9a9f3856a1.gif)](https://gyazo.com/d97829357aaab77bc5047d9a9f3856a1)

- 投稿内容が必須（エラーメッセージが表示される）
[![Image from Gyazo](https://i.gyazo.com/76147b19d7c4f20733ec588753a4d296.gif)](https://gyazo.com/76147b19d7c4f20733ec588753a4d296)